### PR TITLE
docs: document configuration validation and bulk sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ from macpymessenger import Configuration
 configuration = Configuration(Path("/path/to/custom/sendMessage.scpt"))
 ```
 
-`Configuration` will raise `ScriptNotFoundError` if the AppleScript is missing, keeping runtime failures obvious.
+`Configuration` will raise `ScriptNotFoundError` if the AppleScript is missing, keeping runtime failures obvious. The [configuration guide](docs/configuration.rst) explains the readability validation in more detail and documents the default ``macpymessenger.log`` handler attached by `IMessageClient`.
 
 ## Development workflow
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,21 +1,31 @@
 Configuration
 =============
 
-macpymessenger provides a `Configuration` class that allows you to customize various settings and paths used by the library. In this section, we'll explore the available configuration options.
+macpymessenger provides a :class:`~macpymessenger.configuration.Configuration` class that allows you to customize the AppleScript path used by the library. In this section, we outline how the configuration discovers the packaged script, how it validates readability, and the logging defaults applied by the client.
 
 Customizing Script Paths
 ------------------------
 
-By default, macpymessenger uses the following paths for AppleScript files:
-
-- `send_script_path`: `osascript/sendMessage.scpt`
-
-You can modify these paths by creating an instance of the `Configuration` class and setting the desired paths:
+By default, :class:`~macpymessenger.configuration.Configuration` resolves the bundled AppleScript located at ``osascript/sendMessage.scpt`` inside the package. You can point to a different script by instantiating the configuration with an explicit path:
 
 .. code-block:: python
 
+   from pathlib import Path
    from macpymessenger import Configuration
 
-   config = Configuration(send_script_path="path/to/custom/sendMessage.scpt")
+   config = Configuration(send_script_path=Path("/path/to/custom/sendMessage.scpt"))
 
-Make sure to provide the correct paths to your custom AppleScript files.
+Validation and Error Handling
+-----------------------------
+
+During initialization the configuration normalizes the provided path and guarantees that the AppleScript both exists and is readable before it is stored. The private :meth:`~macpymessenger.configuration.Configuration._determine_script_path` helper checks:
+
+* the path exists on disk;
+* the process can open the file in binary mode, surfacing permission issues immediately.
+
+If either check fails a :class:`~macpymessenger.exceptions.ScriptNotFoundError` is raised, keeping runtime execution of ``osascript`` free of surprises.
+
+Logging Defaults
+----------------
+
+Instances of :class:`~macpymessenger.client.IMessageClient` attach a :class:`logging.FileHandler` targeting ``macpymessenger.log`` during :meth:`~macpymessenger.client.IMessageClient.__post_init__`. The handler records informational and error events for all send operations, so you automatically receive a persistent audit trail without additional configuration. You can provide a pre-configured logger when constructing the client to customize the destination or formatting.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -83,4 +83,46 @@ These are just a few examples of what you can do with macpymessenger. The librar
 
 Templates are rendered using Jinja2 under the hood, so you can leverage familiar features such as filters, conditionals, and loops inside your message content.
 
+Loading Templates from the Filesystem
+------------------------------------
+
+If you have a directory of template files, :class:`~macpymessenger.templates.TemplateManager` can ingest them in a single call via :meth:`~macpymessenger.templates.TemplateManager.load_directory`. Files ending in ``.txt`` or ``.j2`` become addressable by their stem (filename without the extension). Duplicate identifiers raise :class:`~macpymessenger.exceptions.DuplicateTemplateIdentifierError`, helping you keep templates distinct.
+
+.. code-block:: python
+
+   from pathlib import Path
+   from macpymessenger import TemplateManager
+
+   manager = TemplateManager()
+   manager.load_directory(Path("./templates"))
+
+   # access the loaded template definitions if you want to inspect them
+   definitions = manager.list_templates()
+
+Listing Available Templates
+---------------------------
+
+Call :meth:`~macpymessenger.templates.TemplateManager.list_templates` to retrieve a dictionary of identifiers mapped to :class:`~macpymessenger.templates.TemplateDefinition` instances. The dictionary is a shallow copy, so mutating it will not impact the manager's internal state:
+
+.. code-block:: python
+
+   definitions = manager.list_templates()
+   for identifier, definition in definitions.items():
+       print(identifier, definition.content)
+
+Bulk Sending
+------------
+
+To send the same message to multiple recipients, :meth:`~macpymessenger.client.IMessageClient.send_bulk` iterates through each number and reports which deliveries succeeded:
+
+.. code-block:: python
+
+   numbers = ["+15551234567", "+15557654321"]
+   successful, failed = client.send_bulk(numbers, "Reminder: stand-up at 10 AM.")
+
+   if failed:
+       print("These numbers need attention:", failed)
+
+The method returns two lists—successful deliveries and failures—so you can decide whether to retry or escalate based on the recipients that encountered errors.
+
 For more detailed information on the available methods and their parameters, please refer to the API reference documentation.


### PR DESCRIPTION
## Summary
- expand the configuration guide to describe script readability validation and the client's default file logger
- extend the usage guide with TemplateManager directory loading, template listing, and IMessageClient bulk sending examples
- link the README configuration section to the detailed documentation for easier discovery

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e5b0df33b88320ad9303f38342e5e3

## Summary by Sourcery

Document configuration validation, default logging, and bulk sending workflows for improved user guidance

Documentation:
- Expand configuration guide to detail script readability validation and default file logger setup
- Extend usage guide with TemplateManager directory loading, template listing, and IMessageClient bulk sending examples
- Add link in README to the detailed configuration documentation for easier navigation