### PR TITLE
fix: gate IMessageClient file logging behind opt-in flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- note: add changes here after each major change -->
 
+### Changed
+- `IMessageClient` no longer creates ``macpymessenger.log`` automatically; use ``enable_file_logging=True`` or provide a pre-configured logger to persist events.
+
 ## [0.2.0] - 2025-10-07
 ### Added
 - A refreshed macpymessenger package with a discoverable public API (`Configuration`, `IMessageClient`, `TemplateManager`, etc.), making new integrations as simple as `from macpymessenger import ...` (see `docs/index.rst`).

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ from macpymessenger import Configuration
 configuration = Configuration(Path("/path/to/custom/sendMessage.scpt"))
 ```
 
-`Configuration` will raise `ScriptNotFoundError` if the AppleScript is missing, keeping runtime failures obvious. The [configuration guide](docs/configuration.rst) explains the readability validation in more detail and documents the default ``macpymessenger.log`` handler attached by `IMessageClient`.
+`Configuration` will raise `ScriptNotFoundError` if the AppleScript is missing, keeping runtime failures obvious. The [configuration guide](docs/configuration.rst) explains the readability validation in more detail and covers how to opt into the optional ``macpymessenger.log`` handler via ``IMessageClient(enable_file_logging=True)``.
 
 ## Development workflow
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -28,4 +28,4 @@ If either check fails a :class:`~macpymessenger.exceptions.ScriptNotFoundError` 
 Logging Defaults
 ----------------
 
-Instances of :class:`~macpymessenger.client.IMessageClient` attach a :class:`logging.FileHandler` targeting ``macpymessenger.log`` during :meth:`~macpymessenger.client.IMessageClient.__post_init__`. The handler records informational and error events for all send operations, so you automatically receive a persistent audit trail without additional configuration. You can provide a pre-configured logger when constructing the client to customize the destination or formatting.
+Instances of :class:`~macpymessenger.client.IMessageClient` rely on the handlers already configured on the provided ``logger``. To persist events to disk you can opt in by instantiating the client with ``enable_file_logging=True``, which attaches a ``macpymessenger.log`` :class:`logging.FileHandler` when one is not present. Supplying a pre-configured logger remains the recommended approach when you need custom destinations or formatting.

--- a/src/macpymessenger/client.py
+++ b/src/macpymessenger/client.py
@@ -63,7 +63,7 @@ class IMessageClient:
             isinstance(handler, logging.FileHandler)
             for handler in self.logger.handlers
         )
-        if self.enable_file_logging is True and not has_file_handler:
+        if self.enable_file_logging and not has_file_handler:
             file_handler = logging.FileHandler("macpymessenger.log")
             formatter = logging.Formatter(
                 "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/src/macpymessenger/client.py
+++ b/src/macpymessenger/client.py
@@ -59,12 +59,11 @@ class IMessageClient:
     enable_file_logging: bool = False
 
     def __post_init__(self) -> None:
-        has_file_handler = False
-        for handler in self.logger.handlers:
-            if isinstance(handler, logging.FileHandler):
-                has_file_handler = True
-                break
-        if self.enable_file_logging is True and has_file_handler is False:
+        has_file_handler = any(
+            isinstance(handler, logging.FileHandler)
+            for handler in self.logger.handlers
+        )
+        if self.enable_file_logging is True and not has_file_handler:
             file_handler = logging.FileHandler("macpymessenger.log")
             formatter = logging.Formatter(
                 "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/src/macpymessenger/client.py
+++ b/src/macpymessenger/client.py
@@ -34,15 +34,37 @@ class SubprocessCommandRunner:
 
 @dataclass(slots=True)
 class IMessageClient:
-    """A client for sending messages via iMessage on macOS."""
+    """A client for sending messages via iMessage on macOS.
+
+    Parameters
+    ----------
+    configuration:
+        Resolved configuration specifying the AppleScript entry point.
+    template_manager:
+        Template storage and rendering backend used for templated messages.
+    command_runner:
+        Callable responsible for executing the generated AppleScript command.
+    logger:
+        Logger instance used for emitting operational events.
+    enable_file_logging:
+        When ``True`` a ``macpymessenger.log`` :class:`logging.FileHandler` is attached during
+        initialization if one is not already configured. The default ``False`` value respects the
+        handlers supplied on ``logger`` and prevents creating files implicitly.
+    """
 
     configuration: Configuration
     template_manager: TemplateManager = field(default_factory=TemplateManager)
     command_runner: CommandRunner = field(default_factory=SubprocessCommandRunner)
     logger: logging.Logger = field(default_factory=lambda: logging.getLogger(__name__))
+    enable_file_logging: bool = False
 
     def __post_init__(self) -> None:
-        if not any(isinstance(handler, logging.FileHandler) for handler in self.logger.handlers):
+        has_file_handler = False
+        for handler in self.logger.handlers:
+            if isinstance(handler, logging.FileHandler):
+                has_file_handler = True
+                break
+        if self.enable_file_logging is True and has_file_handler is False:
             file_handler = logging.FileHandler("macpymessenger.log")
             formatter = logging.Formatter(
                 "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/tests/test_imessage_client.py
+++ b/tests/test_imessage_client.py
@@ -187,7 +187,7 @@ def test_client_with_preexisting_filehandler_logger(
     monkeypatch.chdir(tmp_path)
     log_path = tmp_path / "preexisting.log"
     logger = logging.getLogger("test_logger_with_filehandler")
-    logger.handlers.clear()
+    _remove_file_handlers(logger)
     file_handler = logging.FileHandler(log_path)
     logger.addHandler(file_handler)
 
@@ -208,9 +208,7 @@ def test_client_with_preexisting_filehandler_logger(
         assert file_handlers[0] is file_handler
         assert log_path.exists() is True
     finally:
-        for handler in list(logger.handlers):
-            handler.close()
-            logger.removeHandler(handler)
+        _remove_file_handlers(logger)
 
 
 def test_client_file_logging_opt_in_creates_handler(


### PR DESCRIPTION
## Summary
- add an `enable_file_logging` flag to `IMessageClient` so file handlers are only attached when explicitly requested
- document the opt-in logging behavior across the README, configuration guide, and changelog
- extend the iMessage client tests to cover both the default no-file path and the opt-in handler creation

## Testing
- uv run ruff check
- uv run mypy src
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5b199c8c48320856d65051ab89b58

## Summary by Sourcery

Add an opt-in flag to control file logging in IMessageClient and update documentation and tests accordingly

New Features:
- Introduce enable_file_logging parameter on IMessageClient to attach a FileHandler only when enabled

Documentation:
- Document the opt-in file logging behavior in the README, configuration guide, and changelog

Tests:
- Add tests to verify that file logging is disabled by default and enabled when the flag is set