### PR TITLE
docs(client): Mark chat history and attachments as experimental

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `IMessageClient` no longer creates ``macpymessenger.log`` automatically; use ``enable_file_logging=True`` or provide a pre-configured logger to persist events.
+- Documented `IMessageClient.get_chat_history` and `IMessageClient.send_with_attachment` as experimental stubs that raise ``NotImplementedError`` until the features ship.
 
 ## [0.2.0] - 2025-10-07
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ macpymessenger is a modern, strongly typed Python toolkit for orchestrating macO
 - Composable `TemplateManager` powered by Jinja2 with in-memory storage for safe inheritance and inclusion.
 - Dependency-injected `IMessageClient` that isolates subprocess execution for straightforward testing.
 - Type-driven API surface with explicit error handling and no hidden global state.
+- Clearly signposted experimental APIs for future chat history retrieval and attachment sending.
 
 ## Installation
 
@@ -34,6 +35,14 @@ client.send_template("+15555555555", "welcome", {"name": "Ada"})
 ```
 
 Templates are stored in-memory and rendered via Jinja2. They support inheritance and inclusion without touching the filesystem unless you opt into loading a directory of templates.
+
+## Experimental features
+
+`IMessageClient.get_chat_history` and `IMessageClient.send_with_attachment` are present on the
+public API to stabilise their signatures, but both methods are **experimental**. Each raises a
+`NotImplementedError` prefixed with "Experimental" to ensure callers do not rely on behaviour that
+is not yet available. Roadmap planning is underway for a future minor release; until then these
+helpers should be considered placeholders.
 
 ## Configuration
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -126,3 +126,17 @@ To send the same message to multiple recipients, :meth:`~macpymessenger.client.I
 The method returns two lists—successful deliveries and failures—so you can decide whether to retry or escalate based on the recipients that encountered errors.
 
 For more detailed information on the available methods and their parameters, please refer to the API reference documentation.
+
+Experimental APIs
+-----------------
+
+Two helper methods on :class:`~macpymessenger.client.IMessageClient` are intentionally
+non-functional today:
+
+* :meth:`~macpymessenger.client.IMessageClient.get_chat_history`
+* :meth:`~macpymessenger.client.IMessageClient.send_with_attachment`
+
+Both raise :class:`NotImplementedError` with an "Experimental" prefix to highlight that chat
+history retrieval and attachment delivery are scoped for a future minor release. The signatures are
+published early so downstream projects can plan integrations without taking a hard dependency on
+unfinished behaviour.

--- a/src/macpymessenger/client.py
+++ b/src/macpymessenger/client.py
@@ -131,9 +131,73 @@ class IMessageClient:
         return successful, failed
 
     def get_chat_history(self, phone_number: str, limit: int = 10) -> List[Mapping[str, object]]:
-        raise NotImplementedError("Chat history retrieval is not yet implemented.")
+        """Experimental: Chat history retrieval is not yet implemented.
+
+        Parameters
+        ----------
+        phone_number:
+            The E.164-formatted phone number or iMessage handle whose history would be fetched.
+        limit:
+            Maximum number of messages to return once the feature ships. Values must be
+            positive and are expected to cap the page size. The default of ``10`` is a
+            placeholder until the implementation is available.
+
+        Returns
+        -------
+        List[Mapping[str, object]]
+            This method will eventually return structured message payloads ordered from most
+            recent to oldest. The exact schema is intentionally unspecified while the feature
+            is experimental.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised. The message includes the ``"Experimental"`` prefix to signal that
+            the public API exists but is not yet functional.
+
+        Notes
+        -----
+        Expected availability: TBD. Tracking work is scoped for a future minor release.
+        Until then, callers must not rely on this method.
+        """
+
+        raise NotImplementedError(
+            "Experimental: Chat history retrieval is not yet implemented."
+        )
 
     def send_with_attachment(
         self, phone_number: str, message: str, attachment_path: str
     ) -> bool:
-        raise NotImplementedError("Sending messages with attachments is not yet implemented.")
+        """Experimental: Sending messages with attachments is not yet implemented.
+
+        Parameters
+        ----------
+        phone_number:
+            Intended recipient handle in E.164 or email format.
+        message:
+            Text body that would accompany the attachment when support lands.
+        attachment_path:
+            Absolute path to a file on disk. Future implementations will validate MIME type,
+            existence, and maximum payload size before sending.
+
+        Returns
+        -------
+        bool
+            Planned to indicate whether the attachment send succeeded. The concrete semantics
+            will be finalised alongside the implementation.
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised with an ``"Experimental"`` prefixed message, ensuring callers are
+            aware that attachment delivery is not currently supported.
+
+        Notes
+        -----
+        Expected availability: TBD. The method is defined to stabilise the public API surface
+        but must not be invoked in production workflows yet.
+        """
+
+        raise NotImplementedError(
+            "Experimental: Sending messages with attachments is not yet implemented."
+        )

--- a/tests/test_imessage_client.py
+++ b/tests/test_imessage_client.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import subprocess
 from pathlib import Path
@@ -264,3 +265,32 @@ def test_client_file_logging_opt_in_uses_existing_log_file(
         assert has_file_handler
     finally:
         _remove_file_handlers(client_instance.logger)
+
+
+def test_get_chat_history_is_experimental(
+    client: tuple[IMessageClient, StubRunner]
+) -> None:
+    instance, _ = client
+    with pytest.raises(
+        NotImplementedError, match="Experimental: Chat history retrieval is not yet implemented."
+    ):
+        instance.get_chat_history("+15551234567")
+    doc = inspect.getdoc(IMessageClient.get_chat_history)
+    assert doc is not None
+    assert "Experimental: Chat history retrieval is not yet implemented." in doc
+    assert "Expected availability: TBD." in doc
+
+
+def test_send_with_attachment_is_experimental(
+    client: tuple[IMessageClient, StubRunner]
+) -> None:
+    instance, _ = client
+    with pytest.raises(
+        NotImplementedError,
+        match="Experimental: Sending messages with attachments is not yet implemented.",
+    ):
+        instance.send_with_attachment("+15559876543", "hello", "/tmp/file.pdf")
+    doc = inspect.getdoc(IMessageClient.send_with_attachment)
+    assert doc is not None
+    assert "Experimental: Sending messages with attachments is not yet implemented." in doc
+    assert "Expected availability: TBD." in doc


### PR DESCRIPTION
## Summary
- mark `IMessageClient.get_chat_history` and `send_with_attachment` as experimental with detailed docstrings
- update tests, README, and usage docs to call out the experimental status
- note the documentation change in the changelog under Unreleased

## Testing
- uv run ruff check
- uv run mypy src
- uv run pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e5b7793d4c8320964446ea6ddd11de

## Summary by Sourcery

Stabilize the public API by defining experimental stubs for chat history retrieval and attachment sending, complete with detailed docstrings, documentation updates, changelog entry, and tests.

Enhancements:
- Mark IMessageClient.get_chat_history and IMessageClient.send_with_attachment as experimental stubs with comprehensive docstrings.

Documentation:
- Update README and usage documentation to highlight the experimental status of chat history and attachment methods.
- Add an Unreleased changelog entry documenting the experimental stubs for get_chat_history and send_with_attachment.

Tests:
- Add tests verifying that get_chat_history and send_with_attachment raise NotImplementedError with the experimental prefix and include expected docstring notes.