### PR TITLE
Fix wheel packaging and add regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 **Experimental methods are now documented.** `IMessageClient.get_chat_history` and `IMessageClient.send_with_attachment` are marked as experimental stubs. Both raise `NotImplementedError` until fully implemented.
 
+### Fixed
+
+**PyPI sdist now ships code.** Source distributions now include the Python modules so wheels built from PyPI artifacts expose the `Configuration` API documented in `README.md`.
+
+**Wheel build retains public API.** Corrected Hatch package discovery so installing macpymessenger via pip exposes `Configuration` at the package root, with regression coverage that builds and imports from the wheel artifact.
+
 ## [0.2.0] - 2025-10-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,15 +27,22 @@ Repository = "https://github.com/ethan-wickstrom/macpymessenger"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/macpymessenger"]
+sources = ["src"]
 force-include = { "src/macpymessenger/osascript/sendMessage.scpt" = "macpymessenger/osascript/sendMessage.scpt" }
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "src/macpymessenger/osascript/sendMessage.scpt",
+  "src/macpymessenger",
+  "CHANGELOG.md",
+  "LICENSE",
+  "README.md",
+  "templates",
+  "docs",
 ]
 
 [dependency-groups]
 dev = [
+  "build>=1.2.2",
   "pytest>=8.3.2",
   "ruff>=0.6.9",
 ]

--- a/tests/test_distribution_import.py
+++ b/tests/test_distribution_import.py
@@ -25,10 +25,11 @@ def test_installed_wheel_exports_configuration(tmp_path: Path) -> None:
     wheel_path = _build_wheel(tmp_path)
     install_dir = tmp_path / "site-packages"
     install_dir.mkdir()
-    with ZipFile(wheel_path) as archive:
-        archive.extractall(install_dir)
+    subprocess.run(
+        [sys.executable, "-m", "pip", "install", "--target", str(install_dir), str(wheel_path)],
+        check=True,
+    )
     command = "\n".join(
-        [
             "import sys",
             f"sys.path.insert(0, '{install_dir.as_posix()}')",
             "from macpymessenger import Configuration",

--- a/tests/test_distribution_import.py
+++ b/tests/test_distribution_import.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from zipfile import ZipFile
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _build_wheel(destination: Path) -> Path:
+    dist_dir = destination / "dist"
+    dist_dir.mkdir()
+    subprocess.run(
+        [sys.executable, "-m", "build", "--wheel", "--outdir", str(dist_dir)],
+        check=True,
+        cwd=PROJECT_ROOT,
+    )
+    wheels = list(dist_dir.glob("macpymessenger-*.whl"))
+    assert len(wheels) == 1
+    return wheels[0]
+
+
+def test_installed_wheel_exports_configuration(tmp_path: Path) -> None:
+    wheel_path = _build_wheel(tmp_path)
+    install_dir = tmp_path / "site-packages"
+    install_dir.mkdir()
+    with ZipFile(wheel_path) as archive:
+        archive.extractall(install_dir)
+    command = "\n".join(
+        [
+            "import sys",
+            f"sys.path.insert(0, '{install_dir.as_posix()}')",
+            "from macpymessenger import Configuration",
+            "print(Configuration.__module__)",
+        ]
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", command],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.stdout.strip() == "macpymessenger.configuration"

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,20 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.14"
+
+[[package]]
+name = "build"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/1c/23e33405a7c9eac261dff640926b8b5adaed6a6eb3e1767d441ed611d0c0/build-1.3.0.tar.gz", hash = "sha256:698edd0ea270bde950f53aed21f3a0135672206f3911e0176261a31e0e07b397", size = 48544, upload-time = "2025-08-01T21:27:09.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/8c/2b30c12155ad8de0cf641d76a8b396a16d2c36bc6d50b621a62b7c4567c1/build-1.3.0-py3-none-any.whl", hash = "sha256:7145f0b5061ba90a1500d60bd1b13ca0a8a4cebdd0cc16ed8adf1c0e739f43b4", size = 23382, upload-time = "2025-08-01T21:27:07.844Z" },
+]
 
 [[package]]
 name = "colorama"
@@ -27,6 +41,7 @@ source = { editable = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "build" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -35,6 +50,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "build", specifier = ">=1.2.2" },
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "ruff", specifier = ">=0.6.9" },
 ]
@@ -64,6 +80,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Summary:
- fix Hatch wheel configuration so macpymessenger modules are packaged correctly
- add a regression test that builds the wheel and verifies `Configuration` is importable from an installed artifact
- document the packaging correction in the changelog

Fix Python package distribution so built wheels and sdists include the macpymessenger modules and preserve the public Configuration API.

Build:
- Adjust Hatch wheel and sdist configuration so Python sources and ancillary files are correctly included in built artifacts.
- Add the build tool as a development dependency for local wheel creation.

Documentation:
- Document the packaging and distribution fixes in the changelog, clarifying that sdists and wheels now expose the documented Configuration API.

Tests:
- Add a regression test that builds a wheel, installs it into an isolated directory, and verifies Configuration can be imported from the installed package.

## Summary by Sourcery

Fix Python packaging so wheels and sdists include the macpymessenger modules and preserve the public Configuration API, with regression coverage for distribution imports.

Build:
- Update Hatch wheel and sdist configuration so Python sources and ancillary files are correctly included in built artifacts.
- Add the build tool as a development dependency for local wheel creation.

Documentation:
- Document the packaging and distribution fixes in the changelog, noting that sdists and wheels now expose the documented Configuration API.

Tests:
- Add a regression test that builds a wheel, installs it into an isolated directory, and verifies Configuration can be imported from the installed package.