### PR TITLE
chore(repo): ignore macOS metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.DS_Store
 
 # C extensions
 *.so


### PR DESCRIPTION
Stack position: 1/7

Base: `main`
Head: `ethan/ignore-macos-metadata`

Why
- Prevent local macOS `.DS_Store` files from entering future tracked changes.

How
- Add `.DS_Store` to `.gitignore`.
- Preserve the existing ignore file while normalizing its final newline.

Tests
- Not run for this repo hygiene-only slice.
- Full stack verification previously passed: `uv run pytest`, `uv run ruff check`, `uv run ty check`, `uv run ruff format --check`, `uv build`, and `uv run sphinx-build docs docs/_build/html`.

## Summary by Sourcery

Build:
- Add .DS_Store to the global .gitignore while keeping the existing ignore rules intact.