### PR TITLE
docs(agents): add engineering context and issue guidance

### DIFF
--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,15 @@
+# Context map
+
+Use this map to find the domain context that matches the task.
+
+## Contexts
+
+| Context | Domain doc | ADRs | Use when |
+| ------- | ---------- | ---- | -------- |
+| macpymessenger package | `src/macpymessenger/CONTEXT.md` | `docs/adr/` | Working on message delivery, configuration, templates, command execution, docs, packaging, or tests for the Python package. |
+
+## Reading order
+
+1. Read the context row that matches the task.
+2. Read the linked `CONTEXT.md`.
+3. Read relevant ADRs in `docs/adr/` when the task touches architecture, public behavior, or release process.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,5 @@
+# Architecture decision records
+
+This directory holds repo-wide architecture decisions for macpymessenger.
+
+No ADRs have been recorded yet. Add one when a decision should prevent future agents or maintainers from reopening the same architectural question without new evidence.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,29 @@
+# Domain docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Layout
+
+This repo uses a multi-context domain documentation layout.
+
+- `CONTEXT-MAP.md` at the repo root points to the relevant context docs.
+- `docs/adr/` holds repo-wide architecture decisions.
+- Context-specific `CONTEXT.md` files and `docs/adr/` directories may live near the code they describe.
+
+If these files do not exist yet, proceed silently. Producer skills such as `grill-with-docs` create them lazily when terms or decisions are resolved.
+
+## Before exploring, read these
+
+- Read `CONTEXT-MAP.md` first when it exists.
+- Read each context `CONTEXT.md` relevant to the task.
+- Read ADRs that touch the area you're about to work in.
+
+## Use glossary vocabulary
+
+When output names a domain concept in an issue title, refactor proposal, hypothesis, or test name, use the term defined in the relevant `CONTEXT.md`.
+
+If the concept is missing, do not invent a smooth abstraction. Note the gap for `grill-with-docs`.
+
+## Flag ADR conflicts
+
+If output contradicts an existing ADR, surface it explicitly rather than silently overriding.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,23 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live in GitHub Issues for `ethan-wickstrom/macpymessenger`. Use the `gh` CLI for issue operations.
+
+## Conventions
+
+- Create an issue: `gh issue create --repo ethan-wickstrom/macpymessenger --title "..." --body "..."`
+- Read an issue: `gh issue view <number> --repo ethan-wickstrom/macpymessenger --comments`
+- List issues: `gh issue list --repo ethan-wickstrom/macpymessenger --state open --json number,title,body,labels,comments`
+- Comment on an issue: `gh issue comment <number> --repo ethan-wickstrom/macpymessenger --body "..."`
+- Apply or remove labels: `gh issue edit <number> --repo ethan-wickstrom/macpymessenger --add-label "..."` / `--remove-label "..."`
+- Close an issue: `gh issue close <number> --repo ethan-wickstrom/macpymessenger --comment "..."`
+
+Pass `--repo ethan-wickstrom/macpymessenger` so commands work even outside a checkout
+with a configured GitHub remote.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue in `ethan-wickstrom/macpymessenger`.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --repo ethan-wickstrom/macpymessenger --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role, use the corresponding label string from this table.

--- a/src/macpymessenger/CONTEXT.md
+++ b/src/macpymessenger/CONTEXT.md
@@ -1,0 +1,35 @@
+# macpymessenger context
+
+macpymessenger sends macOS iMessages from Python by composing a validated send script, template rendering, and explicit command execution.
+
+## Domain terms
+
+| Term | Meaning |
+| ---- | ------- |
+| Recipient handle | The destination accepted by Messages.app, usually a phone number or iMessage email address. |
+| Message body | The text content passed to Messages.app for delivery. |
+| Send script | The AppleScript entry point invoked through `osascript` to send a message. |
+| Bundled send script | The packaged send script used when callers do not configure a custom script path. |
+| Script path | The filesystem path to the send script after configuration resolves it. |
+| Template factory | A callable that returns a Python 3.14 t-string template for a message body. |
+| Template identifier | The caller-supplied name used to register, update, render, or delete a template factory. |
+| Rendered template | A template identifier paired with the rendered message body produced from a template factory. |
+| Command runner | The adapter that executes an argument list for a command. Tests replace it to avoid real AppleScript execution. |
+| Delivery failure | A failed message send caused by Messages.app or `osascript` execution. |
+| Configuration failure | A setup failure that prevents reliable delivery, such as an unreadable send script or unavailable file logging. |
+
+## Stable capabilities
+
+- The public client facade exposes message sending, template-backed sending, template management, bulk send classification, and logging configuration.
+- Configuration resolves the send script before delivery starts.
+- Template management enforces t-string template factories and string-only interpolation values.
+- Command execution stays replaceable so tests can verify behavior without invoking real AppleScript.
+- Public failures should use the project exception hierarchy rather than ad hoc exception types.
+
+## Naming guidance
+
+- Prefer `recipient handle` when behavior accepts either phone numbers or iMessage email addresses.
+- Prefer `message body` for user-authored send text.
+- Prefer `send script` for the AppleScript entry point and `script path` for the resolved filesystem path.
+- Prefer `command runner` for the execution adapter seam.
+- Use `delivery failure`, `configuration failure`, and `template failure` for error categories.


### PR DESCRIPTION
Stack position: 5/7

Base: `ethan/uv-build-tooling` (#41)
Head: `ethan/agent-context-guidance`

Why
- Give future agents stable domain/context anchors without overloading root instructions.
- Document issue tracker, triage label, and domain-doc conventions used by the local skill setup.

How
- Add `CONTEXT-MAP.md` and package-level domain context.
- Add lightweight ADR and agent guidance docs for issue tracker, triage labels, and domain documentation.
- Pin `gh issue` examples with `--repo ethan-wickstrom/macpymessenger` so they work outside remote-aware checkouts.

Tests
- `uv run sphinx-build docs docs/_build/html`
- Full stack verification: `uv run ruff check`, `uv run ty check`, `uv run pytest`, `uv run ruff format --check`, `uv build`, and `uv run sphinx-build docs docs/_build/html`.