### PR TITLE
docs(agents): route guidance through an instruction index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,167 +1,39 @@
-# Repository Guidelines
+# Agent instructions
 
-This document is a concise contributor guide for macpymessenger. It explains how the repo is organized, how to build and test, and the conventions to follow when contributing changes.
+macpymessenger is a Python 3.14+ library for sending macOS iMessages through AppleScript with t-string templates and explicit error handling.
 
-## Project Structure & Module Organization
+## Essentials
 
-- Source code: `src/macpymessenger/`
-  - `client.py` — public `IMessageClient` and command runner.
-  - `configuration.py` — immutable `Configuration` and AppleScript resolution.
-- `templates.py` — TemplateManager backed by Python 3.14 t-strings.
-  - `exceptions.py` — error hierarchy (e.g., `MessageSendError`).
-  - `osascript/` — packaged AppleScript (`sendMessage.scpt`).
-- Tests: `tests/` (pytest-based unit tests).
-- Documentation: `docs/` (Sphinx; usage, installation, modules, etc.).
-- Examples/templates: `templates/` (sample text templates, loaded optionally).
-- Packaging: `pyproject.toml` (Hatchling) and `uv.lock` (reproducible tooling).
+- Use `uv` for Python environment management and tool execution.
+- Keep examples, fixtures, and commits free of secrets and real phone numbers.
+- When public behavior changes, update `docs/usage.rst`, `docs/modules.rst`, and `CHANGELOG.md`.
 
-## Build, Test, and Development Commands
+## Commands
 
-Use Astral's uv for a fast, reproducible workflow.
-
-- Create/refresh environment: `uv sync`
+- Create or refresh the environment: `uv sync`
 - Lint: `uv run ruff check`
 - Type check: `uv run ty check`
 - Run tests: `uv run pytest`
-- Build sdist/wheel: `uvx --from build pyproject-build`
-- Build docs (HTML): `uv run sphinx-build docs docs/_build/html`
+- Build the package: `uv build`
+- Build documentation: `uv run sphinx-build docs docs/_build/html`
 
-## Coding Style & Naming Conventions
+`pytest`, `ruff`, `ty`, and `sphinx` are development dependencies.
 
-- Python >= 3.14 with full type hints.
-- Linting via Ruff (line length 100). Keep code formatted accordingly.
-- Naming: modules and functions `snake_case`, classes `CamelCase`, constants `UPPER_SNAKE_CASE`.
-- Prefer dataclasses with `slots=True` where appropriate and explicit immutability where used.
-- Logging: use a module logger; avoid duplicate handlers. No print statements in library code.
-- Exceptions: raise types from `src/macpymessenger/exceptions.py` (e.g., `MessageSendError`, `TemplateNotFoundError`).
+## Task guidance
 
-## Testing Guidelines
+Start with the [agent instruction index](docs/agent-instructions/index.md), then read only
+the task-specific files it routes you to.
 
-- Framework: pytest. Test files live under `tests/` and follow `test_*.py` naming.
-- Do not invoke real AppleScript in tests. Use stubbed runners (see `tests/test_imessage_client.py`).
-- Use temporary paths (`tmp_path`) for script files and fixtures.
-- Validate error handling with `pytest.raises(...)` and assert on logged/raised behavior.
+## Agent skills
 
-## Commit & Pull Request Guidelines
+### Issue tracker
 
-- Follow Conventional Commits:
-  - `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `ci:` (optional scope allowed).
-  - Example: `feat(client): raise MessageSendError on failures`.
-- PRs should include:
-  - Clear description of the change and rationale.
-  - Linked issues (e.g., “Closes #123”).
-  - Evidence the change passes checks: lint, type check, tests, and (if relevant) docs build.
-  - Updates to `docs/` and `CHANGELOG.md` (Unreleased section) when user-visible behavior changes.
+Issues live in GitHub Issues for `ethan-wickstrom/macpymessenger`. See `docs/agents/issue-tracker.md`.
 
-## Security & Configuration Tips
+### Triage labels
 
-- Never commit secrets or real phone numbers. Use fixtures or environment variables locally.
-- `Configuration` validates the AppleScript path; prefer defaults unless testing custom paths.
-- Avoid shell=True for subprocess calls; use argument lists and validated input (see `SubprocessCommandRunner`).
+Use the default Matt Pocock triage label vocabulary. See `docs/agents/triage-labels.md`.
 
-## Architecture Overview
+### Domain docs
 
-- `IMessageClient` orchestrates sending by composing:
-  - `Configuration` for script discovery and validation.
-  - `TemplateManager` for rendering callable-based t-strings while enforcing `TemplateTypeError` for non-string interpolations.
-  - A pluggable command runner (default uses `subprocess.run`).
-- Error handling is explicit: delivery failures raise `MessageSendError` instead of returning booleans.
-- Templates are defined as callables returning t-strings; duplicate identifiers are rejected to prevent conflicts.
-
-## Docs Authoring
-
-- Sphinx + Napoleon. Add or update `.rst` pages in `docs/` and include them in `docs/index.rst`.
-- Keep examples accurate to the code (e.g., `send()` raises on failure; template context is required).
-- Build locally: `uv run sphinx-build docs docs/_build/html`.
-
-## Release Process (maintainers)
-
-- Update `CHANGELOG.md` (benefits-focused, link to relevant docs sections where helpful).
-- Bump the version in `pyproject.toml` using SemVer.
-- Ensure CI is green; tag the release (e.g., `v0.2.0`) and publish via the GitHub workflow.
-
-## Agent-Specific Instructions (for AI assistants)
-
-- Make surgical, minimal changes that align with existing style and architecture.
-- When modifying public behavior, update `docs/usage.rst`, `docs/modules.rst`, and `CHANGELOG.md`.
-- Prefer raising defined exceptions over introducing new ad-hoc error types.
-- Keep tests fast and hermetic; stub subprocess calls instead of executing AppleScript.
-- Use t-string examples (`t"Hello, {name}!"`) in docs/examples.
-
-# Documentation
-
-You are an expert in writing documentation. You are focusing on producing clear, readable documentation that effectively communicates technical information to diverse audiences.
-
-You always use the latest stable documentation practices and you are familiar with the latest research in technical communication and cognitive load theory.
-
-## Project Structure
-- Design documentation with skimmability as the primary consideration
-- Begin every document and section with the most important information first
-- Structure content with informative section titles that convey key insights without requiring further reading
-- Include comprehensive tables of contents that serve as both navigation aids and content previews
-- Organize information in logical sequences that minimize cognitive load
-- Break complex topics into digestible sections with clear transitions
-- Use visual hierarchy through headings, subheadings, and whitespace to guide reader attention
-- Implement progressive disclosure where complex information is revealed gradually based on reader needs
-
-## Style
-- Write section titles as complete informative sentences rather than abstract nouns
-- Keep paragraphs short and focused on single concepts
-- Begin each paragraph with a topic sentence that can stand alone
-- Place topic words at the beginning of topic sentences for immediate recognition
-- Use bulleted lists and tables extensively to present information in scannable formats
-- Employ bold formatting strategically to highlight critical information
-- Structure sentences to be parsed unambiguously on first reading
-- Prefer right-branching sentence structures over left-branching ones
-- Eliminate demonstrative pronouns that require readers to recall prior context
-- Maintain absolute consistency in formatting, terminology, and style throughout all documentation
-- Write in simple direct language that minimizes parsing effort
-- Avoid all abbreviations and spell out technical terms completely
-- Use specific accurate terminology rather than field-specific jargon
-- Design code examples to be self-contained and dependency-minimal
-- Apply the imperative mood consistently in instructional content
-- Structure sentences so readers understand their purpose within the first few words
-- Ensure every sentence contributes directly to reader understanding
-- Write for the most confused reader while maintaining value for experts
-- Ground narrow technical topics with broad contextual openings
-- Proactively address potential points of confusion or common mistakes
-- Prioritize documentation efforts based on user value and frequency of need
-
-## Usage
-- Analyze reader needs and knowledge levels before structuring content
-- Create documentation that serves both skimmers and deep readers effectively
-- Test documentation with representative users to identify comprehension gaps
-- Iterate on documentation based on user feedback and observed usage patterns
-- Apply empathy constantly by imagining the reader's perspective and challenges
-- Break established rules when doing so better serves reader comprehension
-- Validate that all technical information is accurate and up to date
-- Ensure code examples follow current best practices and security guidelines
-- Cross-reference related content to create connected knowledge networks
-- Use analogies and concrete examples to explain abstract concepts
-- Structure troubleshooting guides with most common solutions first
-- Include cross-platform considerations in all technical instructions
-- Document both the "what" and the "why" behind technical decisions
-- Provide multiple entry points to content for different reader backgrounds
-- Maintain documentation as living resources that evolve with product changes
-- Establish clear ownership and review processes for documentation maintenance
-- Measure documentation effectiveness through user feedback and support ticket reduction
-- Update documentation immediately when underlying systems or processes change
-- Create documentation templates that enforce consistency across teams
-- Implement automated checks for broken links and outdated information
-- Design documentation to be easily translatable and culturally adaptable
-- Ensure all documentation meets accessibility standards for diverse users
-- Structure content so readers can find answers without reading entire documents
-- Use consistent terminology that aligns with industry standards
-- Provide clear migration paths when documenting breaking changes
-- Include performance characteristics and limitations in API documentation
-- Document error conditions and recovery procedures comprehensively
-- Provide both quick-start guides and in-depth references for all major features
-- Include real-world use cases and examples that demonstrate practical applications
-- Structure content to support both learning and reference use cases
-- Validate that documentation solves real user problems effectively
-- Ensure documentation reflects the actual user experience accurately
-- Create documentation that scales from beginner to advanced usage patterns
-- Document integration patterns and best practices for complex systems
-- Include troubleshooting flows that guide users from symptoms to solutions
-- Provide clear next steps and additional resources at the end of each topic
-- Design documentation to work effectively across different reading contexts and devices
+Use a multi-context domain documentation layout rooted at `CONTEXT-MAP.md`. See `docs/agents/domain.md`.

--- a/docs/agent-instructions/cleanup-candidates.md
+++ b/docs/agent-instructions/cleanup-candidates.md
@@ -1,0 +1,38 @@
+# Cleanup candidates
+
+Use this file when deciding whether a proposed agent instruction belongs in active guidance.
+
+The instructions below should stay out of the root `AGENTS.md`. Some may belong in focused task files; others should be deleted entirely.
+
+## Redundant with normal agent behavior
+
+- "You are an expert in writing documentation."
+- "You always use the latest stable documentation practices."
+- "Apply empathy constantly by imagining the reader's perspective and challenges."
+- "Break established rules when doing so better serves reader comprehension."
+
+## Too vague to be directly actionable
+
+- "Ensure every sentence contributes directly to reader understanding."
+- "Create documentation that scales from beginner to advanced usage patterns."
+- "Validate that documentation solves real user problems effectively."
+- "Design documentation to work effectively across different reading contexts and devices."
+- "Use analogies and concrete examples to explain abstract concepts."
+- "Keep code easy to skim."
+
+## Too broad for the root AGENTS.md
+
+- "Test documentation with representative users to identify comprehension gaps."
+- "Measure documentation effectiveness through user feedback and support ticket reduction."
+- "Establish clear ownership and review processes for documentation maintenance."
+- "Create documentation templates that enforce consistency across teams."
+- "Implement automated checks for broken links and outdated information."
+- "Design documentation to be easily translatable and culturally adaptable."
+
+## Better kept as task-specific guidance
+
+- Architecture boundaries belong in `project-map.md` and `python-code.md`.
+- Detailed documentation style rules belong in `documentation.md`.
+- Commit and release details belong in `git-release.md`.
+- Test fixture and subprocess stubbing rules belong in `testing.md`.
+- Security rules belong in `security.md`.

--- a/docs/agent-instructions/documentation.md
+++ b/docs/agent-instructions/documentation.md
@@ -1,0 +1,27 @@
+# Documentation guidelines
+
+Use this file when changing `README.md`, `docs/`, examples, or user-facing behavior.
+
+## Keep user-facing behavior accurate
+
+- Show `send()` as raising `MessageSendError` on delivery failure.
+- Show template factories as callables that return t-strings.
+- Show template context as required when the callable requires arguments.
+- Avoid Jinja2 examples for current behavior.
+- Keep code examples self-contained and dependency-minimal.
+
+## Use consistent terminology
+
+- Use the same term for the same domain concept across code and docs.
+- Allow established technical terms such as API, CI, PR, HTML, PyPI, and Sphinx.
+- Use specific terms instead of vague labels such as manager, handler, data, item, object, service, status, type, or process unless the project domain uses that term precisely.
+
+## Maintain Sphinx documentation
+
+- Update the README or `.rst` page that owns changed user-facing behavior.
+- Add or update `.rst` pages in `docs/`.
+- Include new `.rst` pages in `docs/index.rst`.
+- Build documentation with `uv run sphinx-build docs docs/_build/html`.
+
+For public documentation information architecture changes, see
+[suggested-docs-structure.md](suggested-docs-structure.md).

--- a/docs/agent-instructions/git-release.md
+++ b/docs/agent-instructions/git-release.md
@@ -1,0 +1,26 @@
+# Git and release guidelines
+
+Use this file when preparing commits, pull requests, changelog entries, or releases.
+
+## Commits use Conventional Commits
+
+- Use prefixes such as `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, and `ci:`.
+- Use an optional scope when it adds useful context.
+- Example: `feat(client): raise MessageSendError on failures`.
+
+## Pull requests should stay short and structured
+
+- Explain why the change exists.
+- Summarize how the change works.
+- Link related issues such as `Closes #123`.
+- Include checks run and results.
+- Include documentation and changelog updates when behavior changes.
+
+## Releases are maintainer tasks
+
+- Update `CHANGELOG.md` with user-visible changes.
+- Link to relevant documentation when helpful.
+- Bump `pyproject.toml` using Semantic Versioning.
+- Ensure CI is green.
+- Tag releases with a version such as `v0.2.0`.
+- Publish through the GitHub workflow.

--- a/docs/agent-instructions/index.md
+++ b/docs/agent-instructions/index.md
@@ -1,0 +1,17 @@
+# Agent instruction index
+
+Use this file to choose the smallest useful instruction set for the current task.
+
+## Task routing
+
+- [Project map](project-map.md) for repository navigation, capabilities, and ownership boundaries.
+- [Python code guidelines](python-code.md) for library code changes.
+- [Testing guidelines](testing.md) for test changes or behavior verification.
+- [Documentation guidelines](documentation.md) for README, Sphinx, examples, or user-facing behavior.
+- [Git and release guidelines](git-release.md) for commits, pull requests, changelog entries, or releases.
+- [Security guidelines](security.md) for subprocesses, paths, credentials, phone numbers, or examples.
+
+## Maintenance references
+
+- [Cleanup candidates](cleanup-candidates.md) when deciding whether an agent instruction belongs in active guidance.
+- [Suggested docs structure](suggested-docs-structure.md) when reorganizing the public documentation tree.

--- a/docs/agent-instructions/project-map.md
+++ b/docs/agent-instructions/project-map.md
@@ -1,0 +1,33 @@
+# Project map
+
+Use this file when a task requires repository navigation, architecture context, or package ownership boundaries.
+
+## Repository areas
+
+- Library code lives under `src/macpymessenger/`.
+- Tests live under `tests/`.
+- Public Sphinx documentation lives under `docs/`.
+- Example template text assets live under `templates/`; runtime templates are callable t-strings.
+
+Use `fd` or `rg` to confirm current file names before editing.
+
+## Capability map
+
+- The public client facade sends messages, sends rendered templates, classifies bulk sends, and owns operational logging.
+- Configuration resolves and validates the AppleScript send script before delivery.
+- Template management registers callable t-string factories, renders templates, and rejects invalid interpolation values.
+- Command execution is adapter-backed so tests can verify command composition without running `osascript`.
+- The error model separates delivery, configuration, command, and template failures through typed exceptions.
+
+## Composition model
+
+```text
+Caller
+`-- public client facade
+    |-- configuration
+    |-- template rendering
+    `-- command execution adapter
+```
+
+Keep behavior near the capability that owns it. Cross capability boundaries through the
+public client facade, configuration object, template manager, or command runner seam.

--- a/docs/agent-instructions/python-code.md
+++ b/docs/agent-instructions/python-code.md
@@ -1,0 +1,26 @@
+# Python code guidelines
+
+Use this file when changing library code under `src/macpymessenger/`.
+
+## Keep the public model explicit
+
+- Target Python 3.14 or newer.
+- Use full type hints where behavior crosses a public or module boundary.
+- Prefer simple data objects and functions over layered class hierarchies.
+- Prefer `dataclass(frozen=True, slots=True)` for immutable value objects.
+- Keep effects near the outer layer; keep rendering, validation, and transformation logic deterministic when practical.
+
+## Preserve domain boundaries
+
+- Keep AppleScript path discovery in `Configuration`.
+- Keep message orchestration in `IMessageClient`.
+- Keep template registration and rendering in `TemplateManager`.
+- Raise exception types from `src/macpymessenger/exceptions.py` instead of adding ad hoc errors.
+- Name concepts by their domain role, not by temporary implementation details.
+
+## Keep template behavior strict
+
+- Define templates as callables that return Python 3.14 t-strings.
+- Use examples like `t"Hello, {name}!"`.
+- Preserve `TemplateTypeError` for non-string interpolation values.
+- Reject duplicate template identifiers.

--- a/docs/agent-instructions/security.md
+++ b/docs/agent-instructions/security.md
@@ -1,0 +1,22 @@
+# Security guidelines
+
+Use this file when a task touches subprocess execution, user input, paths, credentials, phone numbers, or examples.
+
+## Protect user data
+
+- Never commit secrets.
+- Never commit real phone numbers.
+- Use fixtures, placeholders, or environment variables for examples.
+
+## Keep subprocess execution explicit
+
+- Avoid `shell=True`.
+- Use argument lists for subprocess calls.
+- Validate paths before use.
+- Prefer the existing `SubprocessCommandRunner` behavior unless the task specifically changes command execution.
+
+## Keep configuration predictable
+
+- Let `Configuration` validate the AppleScript path.
+- Prefer the bundled AppleScript unless tests require a custom path.
+- Raise `ScriptNotFoundError` for missing or unreadable scripts.

--- a/docs/agent-instructions/suggested-docs-structure.md
+++ b/docs/agent-instructions/suggested-docs-structure.md
@@ -1,0 +1,46 @@
+# Suggested docs structure
+
+Use this as a future information architecture target for the public Sphinx documentation.
+
+```text
+docs/
+|-- index.rst
+|-- introduction.rst
+|-- installation.rst
+|-- usage.rst
+|-- configuration.rst
+|-- testing.rst
+|-- modules.rst
+|-- guides/
+|   |-- sending-messages.rst
+|   |-- templates.rst
+|   |-- logging.rst
+|   `-- troubleshooting.rst
+|-- api/
+|   |-- client.rst
+|   |-- configuration.rst
+|   |-- templates.rst
+|   `-- exceptions.rst
+|-- development/
+|   |-- contributing.rst
+|   |-- testing.rst
+|   `-- release-process.rst
+`-- agent-instructions/
+    |-- index.md
+    |-- project-map.md
+    |-- python-code.md
+    |-- testing.md
+    |-- documentation.md
+    |-- git-release.md
+    |-- security.md
+    |-- cleanup-candidates.md
+    `-- suggested-docs-structure.md
+```
+
+## Why this structure helps
+
+- Top-level pages stay useful for first-time readers.
+- `guides/` holds task-oriented user workflows.
+- `api/` holds reference material for public modules and classes.
+- `development/` holds contributor-facing process documentation.
+- `agent-instructions/` keeps agent behavior separate from user documentation.

--- a/docs/agent-instructions/testing.md
+++ b/docs/agent-instructions/testing.md
@@ -1,0 +1,22 @@
+# Testing guidelines
+
+Use this file when adding or changing tests.
+
+## Tests must stay hermetic
+
+- Do not execute real AppleScript in tests.
+- Use stubbed command runners from shared test support.
+- Use `tmp_path` for script files and filesystem fixtures.
+
+## Assertions should cover domain behavior
+
+- Assert on raised and logged behavior when error handling changes.
+- Verify command composition through a stub runner rather than through `osascript`.
+- Keep tests focused on changed behavior and public contracts.
+
+## Verification scope
+
+- Run `uv run pytest` when behavior or tests change.
+- Run `uv run ruff check` and `uv run ty check` when Python code changes.
+
+See the root `AGENTS.md` for the complete command list.


### PR DESCRIPTION
Stack position: 6/7

Base: `ethan/agent-context-guidance` (#43)
Head: `ethan/agent-instruction-index`

Why
- Shrink root `AGENTS.md` to essential instructions and route task-specific guidance through progressive disclosure.
- Move detailed guidance into focused files so agents read only what the current task needs.

How
- Replace the large root AGENTS content with essentials, commands, and a single task-guidance entrypoint.
- Add task-specific instruction files for project map, Python, testing, docs, git/release, security, cleanup candidates, and suggested docs structure.

Tests
- `uv run sphinx-build docs docs/_build/html` passed in final verification.
- Full stack verification previously passed: `uv run pytest`, `uv run ruff check`, `uv run ty check`, `uv run ruff format --check`, `uv build`, and `uv run sphinx-build docs docs/_build/html`.

## Summary by Sourcery

Route AI agent guidance through a centralized instruction index and move detailed guidance into focused task-specific documents.

Documentation:
- Condense AGENTS.md to essentials, core commands, and a single entrypoint into task-specific guidance.
- Introduce an agent instruction index and dedicated task-focused guideline docs for project structure, Python code, testing, documentation, git/release, security, cleanup candidates, and suggested public docs structure.